### PR TITLE
fix: add ARIA live regions to VideoFeed (closes #184)

### DIFF
--- a/client/src/components/feed/VideoFeed.test.tsx
+++ b/client/src/components/feed/VideoFeed.test.tsx
@@ -93,6 +93,63 @@ describe('VideoFeed', () => {
     expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
   });
 
+  it('announces loading state via role="status" live region', () => {
+    mockUseFeed.mockReturnValue(defaultFeedReturn({ isLoading: true }));
+
+    renderWithRouter(<VideoFeed profileId="p1" />);
+
+    const status = screen.getByRole('status');
+    expect(status).toHaveTextContent('Loading videos…');
+  });
+
+  it('announces fetching-more state via role="status" live region', () => {
+    const videos = [makeVideo('1')];
+    mockUseFeed.mockReturnValue(
+      defaultFeedReturn({ videos, hasLoadedOnce: true, isFetchingMore: true, nextPageToken: 'tok' })
+    );
+
+    renderWithRouter(<VideoFeed profileId="p1" />);
+
+    // The "all caught up" <p> also has role="status"; find the sr-only one
+    const statusRegions = screen.getAllByRole('status');
+    const liveRegion = statusRegions.find((el) => el.classList.contains('sr-only'));
+    expect(liveRegion).toHaveTextContent('Loading more videos…');
+  });
+
+  it('full-page error has role="alert"', () => {
+    mockUseFeed.mockReturnValue(
+      defaultFeedReturn({ error: 'Network error', hasLoadedOnce: true })
+    );
+
+    renderWithRouter(<VideoFeed profileId="p1" />);
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveTextContent('Network error');
+  });
+
+  it('inline error (videos present) has role="alert"', () => {
+    const videos = [makeVideo('1')];
+    mockUseFeed.mockReturnValue(
+      defaultFeedReturn({ videos, hasLoadedOnce: true, error: 'Partial error' })
+    );
+
+    renderWithRouter(<VideoFeed profileId="p1" />);
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Partial error');
+  });
+
+  it('"all caught up" message has role="status"', () => {
+    const videos = [makeVideo('1')];
+    mockUseFeed.mockReturnValue(
+      defaultFeedReturn({ videos, hasLoadedOnce: true, nextPageToken: undefined })
+    );
+
+    renderWithRouter(<VideoFeed profileId="p1" />);
+
+    const caughtUp = screen.getByText(/You're all caught up/);
+    expect(caughtUp).toHaveAttribute('role', 'status');
+  });
+
   it('does not render source tabs (feature disabled)', () => {
     mockUseFeed.mockReturnValue(defaultFeedReturn({ isLoading: true }));
 

--- a/client/src/components/feed/VideoFeed.tsx
+++ b/client/src/components/feed/VideoFeed.tsx
@@ -65,11 +65,20 @@ export default function VideoFeed({ profileId, onVideoSelect }: VideoFeedProps) 
     }
   }, [videos.length]);
 
+  // Shared live region rendered in all states so it is always mounted when text changes
+  const liveRegion = (
+    <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+      {isLoading && 'Loading videos…'}
+      {isFetchingMore && !isLoading && 'Loading more videos…'}
+    </div>
+  );
+
   // Error state
   if (error && !isLoading && videos.length === 0) {
     return (
       <div>
-        <div className="video-feed-error">
+        {liveRegion}
+        <div className="video-feed-error" role="alert">
           <p className="video-feed-error-text">{error}</p>
           <button
             onClick={reset}
@@ -86,6 +95,7 @@ export default function VideoFeed({ profileId, onVideoSelect }: VideoFeedProps) 
   if (!isLoading && hasLoadedOnce && videos.length === 0) {
     return (
       <div>
+        {liveRegion}
         <div className="video-feed-empty">
           <div className="video-feed-empty-icon">📺</div>
           <p className="video-feed-empty-text">
@@ -104,6 +114,8 @@ export default function VideoFeed({ profileId, onVideoSelect }: VideoFeedProps) 
 
   return (
     <div>
+      {liveRegion}
+
       {/* Initial loading state */}
       {isLoading && (
         <div className="video-grid">
@@ -130,7 +142,7 @@ export default function VideoFeed({ profileId, onVideoSelect }: VideoFeedProps) 
 
           {/* All caught up */}
           {!nextPageToken && hasLoadedOnce && (
-            <p className="video-feed-caught-up">
+            <p className="video-feed-caught-up" role="status">
               You're all caught up! 🎉
             </p>
           )}
@@ -139,7 +151,7 @@ export default function VideoFeed({ profileId, onVideoSelect }: VideoFeedProps) 
 
       {/* Inline error with videos already shown */}
       {error && videos.length > 0 && (
-        <div className="video-feed-inline-error">
+        <div className="video-feed-inline-error" role="alert">
           <p className="video-feed-inline-error-text">{error}</p>
           <button
             onClick={reset}


### PR DESCRIPTION
## Summary

Fixes WCAG 2.2 SC 4.1.3 (Status Messages, Level AA) — screen reader users were getting no announcements when the feed was loading, erroring, or finishing.

## Changes

### `VideoFeed.tsx`
- Added a **persistent `role="status" aria-live="polite" aria-atomic="true"`** div (always mounted in the DOM) that announces:
  - `"Loading videos…"` during initial load
  - `"Loading more videos…"` during pagination
  - empty string otherwise (no spurious announcements)
- Added **`role="alert"`** to the full-page error `div` (triggers assertive announcement on error)
- Added **`role="alert"`** to the inline error `div` (error shown alongside loaded videos)
- Added **`role="status"`** to the `"You're all caught up! 🎉"` paragraph
- Refactored early-return error/empty states to include the live region so the loading→error path is also announced

### `VideoFeed.test.tsx`
- Added test coverage for all five new ARIA changes (loading status, fetching-more status, full-page alert, inline alert, all-caught-up status)

## No CSS changes
`.sr-only` was already defined globally in `index.css`.

Fixes: #184