### PR TITLE
fix(a11y): resolve 12 daily-accessibility issues

### DIFF
--- a/client/src/components/auth/ProtectedRoute.tsx
+++ b/client/src/components/auth/ProtectedRoute.tsx
@@ -8,8 +8,9 @@ export default function ProtectedRoute({ children }: { children: React.ReactNode
 
   if (isLoading) {
     return (
-      <div className="protected-route-loading">
-        <div className="protected-route-spinner" />
+      <div className="protected-route-loading" role="status" aria-label="Loading, please wait...">
+        <div className="protected-route-spinner" aria-hidden="true" />
+        <span className="sr-only">Loading, please wait...</span>
       </div>
     );
   }

--- a/client/src/components/feed/VideoCard.tsx
+++ b/client/src/components/feed/VideoCard.tsx
@@ -28,6 +28,7 @@ const VideoCard: React.FC<VideoCardProps> = React.memo(function VideoCard({ vide
     <button
       type="button"
       className="video-card"
+      aria-label={`Play ${video.title} by ${video.channelTitle}`}
       onClick={() => onSelect?.(video)}
     >
       {/* Thumbnail */}

--- a/client/src/components/feed/VideoFeed.tsx
+++ b/client/src/components/feed/VideoFeed.tsx
@@ -69,7 +69,7 @@ export default function VideoFeed({ profileId, onVideoSelect }: VideoFeedProps) 
   const liveRegion = (
     <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
       {isLoading && 'Loading videos…'}
-      {isFetchingMore && !isLoading && 'Loading more videos…'}
+      {!isLoading && isFetchingMore && 'Loading more videos…'}
     </div>
   );
 
@@ -128,14 +128,20 @@ export default function VideoFeed({ profileId, onVideoSelect }: VideoFeedProps) 
       {/* Video grid */}
       {!isLoading && videos.length > 0 && (
         <>
-          <div className="video-grid">
+          <ul className="video-grid" aria-label={`Video feed – ${videos.length} videos`}>
             {videos.map((video) => (
-              <VideoCard key={video.videoId} video={video} onSelect={onVideoSelect} />
+              <li key={video.videoId}>
+                <VideoCard video={video} onSelect={onVideoSelect} />
+              </li>
             ))}
             {/* Extra skeletons while fetching more */}
             {isFetchingMore &&
-              Array.from({ length: 4 }).map((_, i) => <VideoCardSkeleton key={`more-${i}`} />)}
-          </div>
+              Array.from({ length: 4 }).map((_, i) => (
+                <li key={`more-${i}`} aria-hidden="true">
+                  <VideoCardSkeleton />
+                </li>
+              ))}
+          </ul>
 
           {/* Sentinel for infinite scroll */}
           <div ref={sentinelRef} className="video-feed-sentinel" />

--- a/client/src/components/profile/ProfileSwitcher.css
+++ b/client/src/components/profile/ProfileSwitcher.css
@@ -48,6 +48,13 @@
   margin: 4px 0;
 }
 
+.profile-switcher-section,
+.profile-switcher-section-options {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
 .profile-switcher-section {
   display: flex;
   flex-direction: column;
@@ -68,6 +75,20 @@
   align-items: center;
   justify-content: space-between;
   gap: 12px;
+}
+
+.profile-switcher-option:focus {
+  background: var(--ft-surface-hover);
+  box-shadow: inset 0 0 0 2px var(--ft-border-focus);
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+}
+
+@media (forced-colors: active) {
+  .profile-switcher-option:focus {
+    box-shadow: none;
+    outline-color: Highlight;
+  }
 }
 
 .profile-switcher-option-main {

--- a/client/src/components/profile/ProfileSwitcher.tsx
+++ b/client/src/components/profile/ProfileSwitcher.tsx
@@ -1,16 +1,107 @@
-import { useState, useRef, useEffect, useId } from 'react';
+import { useState, useRef, useEffect, useId, useMemo, useCallback, type KeyboardEvent } from 'react';
 import { useProfiles } from '../../context/ProfileContext';
 import { Link } from 'react-router-dom';
+import type { CommunityProfile, Profile } from '../../types/profile';
 import ProfileSwitcherSkeleton from './ProfileSwitcherSkeleton';
 import './ProfileSwitcher.css';
+
+type SwitcherOption =
+  | { id: string; kind: 'owned'; profile: Profile }
+  | { id: string; kind: 'followed'; profile: CommunityProfile };
 
 export default function ProfileSwitcher() {
   const { profiles, activeProfile, setActiveProfile, isLoading, followedProfiles } = useProfiles();
   const [open, setOpen] = useState(false);
+  const [focusedIndex, setFocusedIndex] = useState(0);
   const ref = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const listboxRef = useRef<HTMLUListElement>(null);
+  const optionRefs = useRef<Array<HTMLLIElement | null>>([]);
   const ownProfilesGroupLabelId = useId();
   const followedProfilesGroupLabelId = useId();
+  const listboxId = useId();
   const hasAnyProfiles = profiles.length > 0 || followedProfiles.length > 0;
+  const switcherOptions: SwitcherOption[] = useMemo(
+    () => [
+      ...profiles.map((profile) => ({ id: profile.id, kind: 'owned' as const, profile })),
+      ...followedProfiles.map((profile) => ({ id: profile.id, kind: 'followed' as const, profile })),
+    ],
+    [profiles, followedProfiles],
+  );
+
+  const getInitialFocusedIndex = useCallback(() => {
+    if (switcherOptions.length === 0) return 0;
+
+    const activeIndex = switcherOptions.findIndex((option) => option.id === activeProfile?.id);
+    return activeIndex >= 0 ? activeIndex : 0;
+  }, [activeProfile?.id, switcherOptions]);
+
+  const focusTrigger = () => {
+    window.setTimeout(() => triggerRef.current?.focus(), 0);
+  };
+
+  const openDropdown = () => {
+    setFocusedIndex(getInitialFocusedIndex());
+    setOpen(true);
+  };
+
+  const closeDropdown = (returnFocus = false) => {
+    setOpen(false);
+    if (returnFocus) focusTrigger();
+  };
+
+  const selectOption = (index: number, returnFocus = true) => {
+    const option = switcherOptions[index];
+    if (!option) return;
+
+    setActiveProfile(option.id);
+    closeDropdown(returnFocus);
+  };
+
+  const moveFocus = (nextIndex: number) => {
+    const optionCount = switcherOptions.length;
+    if (optionCount === 0) return;
+
+    setFocusedIndex((nextIndex + optionCount) % optionCount);
+  };
+
+  const handleOptionKeyDown = (e: KeyboardEvent<HTMLLIElement>, index: number) => {
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        moveFocus(index + 1);
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        moveFocus(index - 1);
+        break;
+      case 'Home':
+        e.preventDefault();
+        moveFocus(0);
+        break;
+      case 'End':
+        e.preventDefault();
+        moveFocus(switcherOptions.length - 1);
+        break;
+      case 'Enter':
+      case ' ':
+      case 'Spacebar':
+        e.preventDefault();
+        selectOption(index);
+        break;
+      case 'Escape':
+        e.preventDefault();
+        closeDropdown(true);
+        break;
+    }
+  };
+
+  const handleTriggerKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
+    if (!open && e.key === 'ArrowDown') {
+      e.preventDefault();
+      openDropdown();
+    }
+  };
 
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
@@ -21,6 +112,18 @@ export default function ProfileSwitcher() {
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
+
+  useEffect(() => {
+    if (!open) return;
+
+    setFocusedIndex(getInitialFocusedIndex());
+  }, [open, getInitialFocusedIndex]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    optionRefs.current[focusedIndex]?.focus();
+  }, [focusedIndex, open]);
 
   if (isLoading) {
     return <ProfileSwitcherSkeleton />;
@@ -40,11 +143,14 @@ export default function ProfileSwitcher() {
   return (
     <div ref={ref} className="profile-switcher">
       <button
+        ref={triggerRef}
         type="button"
         aria-label={`Watching ${activeProfile?.name ?? 'Select profile'} — switch profile`}
         aria-expanded={open}
         aria-haspopup="listbox"
-        onClick={() => setOpen(!open)}
+        aria-controls={open ? listboxId : undefined}
+        onClick={() => (open ? closeDropdown() : openDropdown())}
+        onKeyDown={handleTriggerKeyDown}
         className="profile-switcher-trigger"
       >
         <span className="profile-switcher-trigger-label">Watching</span>
@@ -53,61 +159,86 @@ export default function ProfileSwitcher() {
       </button>
 
       {open && (
-        <div role="listbox" className="profile-switcher-dropdown">
+        <ul
+          id={listboxId}
+          ref={listboxRef}
+          role="listbox"
+          aria-label="Select profile"
+          tabIndex={-1}
+          className="profile-switcher-dropdown"
+        >
           {profiles.length > 0 && (
-            <div role="group" aria-labelledby={ownProfilesGroupLabelId} className="profile-switcher-section">
+            <li role="presentation" className="profile-switcher-section">
               <span id={ownProfilesGroupLabelId} className="profile-switcher-group-label">Your profiles</span>
-              {profiles.map((p) => (
-                <button
-                  type="button"
-                  role="option"
-                  aria-selected={p.id === activeProfile?.id}
-                  key={p.id}
-                  onClick={() => {
-                    setActiveProfile(p.id);
-                    setOpen(false);
-                  }}
-                  className={`profile-switcher-option${p.id === activeProfile?.id ? ' profile-switcher-option--active' : ''}`}
-                >
-                  <span className="profile-switcher-option-name">{p.name}</span>
-                  &nbsp;&nbsp;<span className={`profile-switcher-visibility-badge${p.isPublic ? ' profile-switcher-visibility-badge--public' : ''}`}>
-                    {p.isPublic ? 'Public' : 'Private'}
-                  </span>
-                </button>
-              ))}
-            </div>
+              <ul role="group" aria-labelledby={ownProfilesGroupLabelId} className="profile-switcher-section-options">
+                {profiles.map((p, profileIndex) => {
+                  const optionIndex = profileIndex;
+                  const isActive = p.id === activeProfile?.id;
+                  const isFocused = focusedIndex === optionIndex;
+
+                  return (
+                    <li
+                      role="option"
+                      aria-selected={isActive}
+                      tabIndex={isFocused ? 0 : -1}
+                      key={p.id}
+                      ref={(element) => {
+                        optionRefs.current[optionIndex] = element;
+                      }}
+                      onClick={() => selectOption(optionIndex)}
+                      onKeyDown={(e) => handleOptionKeyDown(e, optionIndex)}
+                      className={`profile-switcher-option${isActive ? ' profile-switcher-option--active' : ''}`}
+                    >
+                      <span className="profile-switcher-option-name">{p.name}</span>
+                      &nbsp;&nbsp;<span className={`profile-switcher-visibility-badge${p.isPublic ? ' profile-switcher-visibility-badge--public' : ''}`}>
+                        {p.isPublic ? 'Public' : 'Private'}
+                      </span>
+                    </li>
+                  );
+                })}
+              </ul>
+            </li>
           )}
 
           {followedProfiles.length > 0 && (
             <>
-              {profiles.length > 0 && <div className="profile-switcher-divider" role="separator" />}
-              <div role="group" aria-labelledby={followedProfilesGroupLabelId} className="profile-switcher-section">
+              {profiles.length > 0 && <li className="profile-switcher-divider" role="separator" aria-hidden="true" />}
+              <li role="presentation" className="profile-switcher-section">
                 <span id={followedProfilesGroupLabelId} className="profile-switcher-group-label">Community profiles you follow</span>
-                {followedProfiles.map((p) => (
-                  <button
-                    type="button"
-                    role="option"
-                    aria-selected={p.id === activeProfile?.id}
-                    key={p.id}
-                    onClick={() => {
-                      setActiveProfile(p.id);
-                      setOpen(false);
-                    }}
-                    className={`profile-switcher-option profile-switcher-option--followed${p.id === activeProfile?.id ? ' profile-switcher-option--active' : ''}`}
-                  >
-                    <span className="profile-switcher-option-main">
-                      <span className="profile-switcher-followed-info">
-                        <span className="profile-switcher-followed-name">{p.name}</span>
-                        <span className="profile-switcher-followed-owner">by {p.user.name}</span>
-                      </span>
-                      &nbsp;&nbsp;<span className="profile-switcher-followed-state">Following</span>
-                    </span>
-                  </button>
-                ))}
-              </div>
+                <ul role="group" aria-labelledby={followedProfilesGroupLabelId} className="profile-switcher-section-options">
+                  {followedProfiles.map((p, followedIndex) => {
+                    const optionIndex = profiles.length + followedIndex;
+                    const isActive = p.id === activeProfile?.id;
+                    const isFocused = focusedIndex === optionIndex;
+
+                    return (
+                      <li
+                        role="option"
+                        aria-selected={isActive}
+                        tabIndex={isFocused ? 0 : -1}
+                        key={p.id}
+                        ref={(element) => {
+                          optionRefs.current[optionIndex] = element;
+                        }}
+                        onClick={() => selectOption(optionIndex)}
+                        onKeyDown={(e) => handleOptionKeyDown(e, optionIndex)}
+                        className={`profile-switcher-option profile-switcher-option--followed${isActive ? ' profile-switcher-option--active' : ''}`}
+                      >
+                        <span className="profile-switcher-option-main">
+                          <span className="profile-switcher-followed-info">
+                            <span className="profile-switcher-followed-name">{p.name}</span>
+                            <span className="profile-switcher-followed-owner">by {p.user.name}</span>
+                          </span>
+                          &nbsp;&nbsp;<span className="profile-switcher-followed-state">Following</span>
+                        </span>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </li>
             </>
           )}
-        </div>
+        </ul>
       )}
     </div>
   );

--- a/client/src/components/subscriptions/SubscriptionChannelRow.tsx
+++ b/client/src/components/subscriptions/SubscriptionChannelRow.tsx
@@ -29,7 +29,7 @@ export default function SubscriptionChannelRow({ channel, isSelected, isSaving, 
     <div className={`subscription-row${isSelected ? ' subscription-row--selected' : ''}`}>
       <img
         src={channel.thumbnailUrl ?? undefined}
-        alt={channel.channelTitle}
+        alt=""
       />
 
       <div className="subscription-row-info">

--- a/client/src/components/ui/SettingsMenu.tsx
+++ b/client/src/components/ui/SettingsMenu.tsx
@@ -136,7 +136,7 @@ export default function SettingsMenu() {
             role="menuitem"
             className="settings-menu-link"
           >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <svg aria-hidden="true" focusable="false" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
               <circle cx="12" cy="7" r="4" />
             </svg>
@@ -156,7 +156,7 @@ export default function SettingsMenu() {
             role="menuitem"
             className="settings-menu-btn"
           >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <svg aria-hidden="true" focusable="false" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
               <polyline points="16 17 21 12 16 7" />
               <line x1="21" y1="12" x2="9" y2="12" />

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -316,7 +316,9 @@ img {
   position: absolute;
   top: 100%;
   left: 0;
-  margin-top: 6px;
+  margin: 6px 0 0;
+  padding: 0;
+  list-style: none;
   min-width: 360px;
   width: max-content;
   max-width: min(92vw, 460px);
@@ -387,7 +389,6 @@ img {
   font-size: 16px;
   font-family: var(--ft-font);
   min-height: 44px;
-  outline: none;
   margin-bottom: 16px;
   box-sizing: border-box;
   background: var(--ft-surface);
@@ -396,8 +397,9 @@ img {
 }
 
 .subscription-search:focus {
+  outline: 2px solid transparent;
   border-color: var(--ft-border-focus);
-  box-shadow: 0 0 0 3px rgba(6, 95, 212, 0.12);
+  box-shadow: 0 0 0 3px rgba(6, 95, 212, 0.35);
 }
 
 .subscription-row {
@@ -619,4 +621,25 @@ select:focus-visible {
   padding: 48px 24px;
   text-align: center;
   color: var(--ft-text-secondary);
+}
+
+/* ===== REDUCED MOTION ===== */
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  .skeleton-shimmer {
+    animation: none;
+  }
+
+  .video-card:hover {
+    transform: none;
+  }
 }

--- a/client/src/pages/CommunityPage.css
+++ b/client/src/pages/CommunityPage.css
@@ -40,7 +40,6 @@
   font-size: 16px;
   font-family: var(--ft-font);
   min-height: 44px;
-  outline: none;
   background: var(--ft-surface);
   color: var(--ft-text);
   transition: border-color 0.15s, box-shadow 0.15s;
@@ -48,9 +47,9 @@
 }
 
 .community-search-input:focus {
-  border-color: var(--ft-border-focus);
-  box-shadow: 0 0 0 3px rgba(6, 95, 212, 0.12);
   outline: 2px solid transparent;
+  border-color: var(--ft-border-focus);
+  box-shadow: 0 0 0 3px rgba(6, 95, 212, 0.35);
 }
 
 .community-loading {

--- a/client/src/pages/CommunityPage.tsx
+++ b/client/src/pages/CommunityPage.tsx
@@ -47,9 +47,9 @@ export default function CommunityPage() {
         </div>
 
         {isLoading ? (
-          <p className="community-loading">Loading profiles…</p>
+          <p className="community-loading" role="status">Loading profiles…</p>
         ) : error ? (
-          <p className="community-error">{error}</p>
+          <p className="community-error" role="alert">{error}</p>
         ) : profiles.length === 0 ? (
           <div className="community-empty">
             <p>No public profiles found{keyword ? ` matching "${keyword}"` : ''}.</p>

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -47,6 +47,24 @@ export default function Dashboard() {
   }, [activeProfile?.id]);
 
   useEffect(() => {
+    const mainContent = document.getElementById('main-content');
+    const header = document.querySelector('header');
+
+    if (selectedVideo) {
+      mainContent?.setAttribute('inert', '');
+      header?.setAttribute('inert', '');
+    } else {
+      mainContent?.removeAttribute('inert');
+      header?.removeAttribute('inert');
+    }
+
+    return () => {
+      mainContent?.removeAttribute('inert');
+      header?.removeAttribute('inert');
+    };
+  }, [selectedVideo]);
+
+  useEffect(() => {
     localStorage.setItem(PROFILE_PANEL_STORAGE_KEY, isProfilePanelVisible ? 'visible' : 'hidden');
   }, [isProfilePanelVisible]);
 

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -19,11 +19,9 @@ export default function LoginPage() {
 
   if (isLoading) {
     return (
-      <div className="login-spinner-container">
-        <div role="status" aria-label="Loading, please wait...">
-          <div className="login-spinner" aria-hidden="true" />
-          <span className="sr-only">Loading, please wait...</span>
-        </div>
+      <div className="login-spinner-container" role="status" aria-label="Loading, please wait...">
+        <div className="login-spinner" aria-hidden="true" />
+        <span className="sr-only">Loading, please wait...</span>
       </div>
     );
   }
@@ -49,7 +47,7 @@ export default function LoginPage() {
         )}
         {/* Brand row: logo + Focused-Tube */}
         <div className="login-brand-row">
-          <img src="/ft-logo.png" alt="FocusedTube" className="login-brand-logo" />
+          <img src="/ft-logo.png" alt="" className="login-brand-logo" />
           <span className="login-brand-name">
             FocusedTube
           </span>
@@ -77,7 +75,7 @@ export default function LoginPage() {
           href={googleAuthHref}
           className="login-google-btn"
         >
-          <svg width="20" height="20" viewBox="0 0 48 48">
+          <svg width="20" height="20" viewBox="0 0 48 48" aria-hidden="true" focusable="false">
             <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"/>
             <path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"/>
             <path fill="#FBBC05" d="M10.53 28.59a14.5 14.5 0 0 1 0-9.18l-7.98-6.19a24.003 24.003 0 0 0 0 21.56l7.98-6.19z"/>

--- a/client/src/pages/ProfilesPage.tsx
+++ b/client/src/pages/ProfilesPage.tsx
@@ -77,6 +77,8 @@ export default function ProfilesPage() {
           <button
             onClick={() => setShowForm(!showForm)}
             className="profiles-new-btn"
+            aria-expanded={showForm}
+            aria-controls="new-profile-form"
           >
             {showForm ? 'Cancel' : '+ New Profile'}
           </button>
@@ -84,6 +86,7 @@ export default function ProfilesPage() {
 
       {showForm && (
         <form
+          id="new-profile-form"
           onSubmit={handleCreate}
           className="profiles-create-form"
         >
@@ -117,7 +120,7 @@ export default function ProfilesPage() {
         </form>
       )}
 
-      {error && <p className="profiles-error">{error}</p>}
+      {error && <p className="profiles-error" role="alert">{error}</p>}
 
       {isLoading ? (
         <p className="profiles-loading">Loading profiles…</p>


### PR DESCRIPTION
Resolves a backlog of 12 open `daily-accessibility` issues in a single coordinated change. After de-duplicating clusters (kept the latest issue per pattern, closed 25 duplicates), the remaining issues were dispatched to 10 parallel sub-agents — one per coherent file group.

## Issues closed

| # | Fix |
|---|---|
| #74 | Search inputs: transparent outline fallback so focus is visible in Forced Colors mode |
| #78 | ProfilesPage "New Profile" toggle: `aria-expanded` + `aria-controls` |
| #88 | `prefers-reduced-motion` block in global CSS disables animations/transitions/transforms |
| #91 | ProfileSwitcher rebuilt as proper `<ul>`/`<li>` listbox with arrow / Home / End / Enter / Escape keyboard nav + roving tabindex |
| #104 | Live regions (`role="status"` / `role="alert"`) across LoginPage, ProtectedRoute, ProfilesPage, CommunityPage, VideoFeed |
| #105 | VideoFeed: semantic `<ul>`/`<li>` with `aria-label`; sr-only "Loading more videos…" announcement |
| #106 | Decorative SVGs (Google logo, SettingsMenu icons) marked `aria-hidden="true"` + `focusable="false"` |
| #110 | VideoCard button: descriptive `aria-label` "Play {title} by {channel}" (preserves Label-in-Name) |
| #111 | LoginPage brand logo: `alt=""` (decorative; adjacent visible text already announces brand) |
| #112 | SubscriptionChannelRow avatar: `alt=""` |
| #115 | VideoPlayer modal: page header + main marked `inert` while open (closes the AT virtual-cursor leak) |
| #116 | LoginPage & ProtectedRoute spinners: `role="status"` with `sr-only` text |

## Files changed (13)
- `client/src/pages/LoginPage.tsx`, `ProfilesPage.tsx`, `CommunityPage.tsx`, `Dashboard.tsx`
- `client/src/components/auth/ProtectedRoute.tsx`
- `client/src/components/feed/VideoFeed.tsx`, `VideoCard.tsx`
- `client/src/components/profile/ProfileSwitcher.tsx` + `.css`
- `client/src/components/subscriptions/SubscriptionChannelRow.tsx`
- `client/src/components/ui/SettingsMenu.tsx`
- `client/src/index.css`, `client/src/pages/CommunityPage.css`

## Validation

- ✅ `npm run build --workspace=client` — green
- ✅ Server tests: 66/66 pass
- ✅ Client tests: 88/90 pass — the 2 remaining failures (`Dashboard > wraps the feed in a labeled tabpanel` and `VideoPlayer > keeps keyboard focus trapped`) are **pre-existing on `main`** and unrelated to these changes (verified by running tests against `git stash`-ed baseline).

## Notes on the ProfileSwitcher fix (#91)

Converted the broken `role="listbox"` + `<button role="option">` pattern (button role conflicts with option role) to a proper APG listbox using non-interactive `<li role="option">` children. Added:
- Roving tabindex (`tabIndex={isFocused ? 0 : -1}`)
- Arrow Up/Down (wrap), Home, End, Enter/Space (select), Escape (close + return focus to trigger)
- `ArrowDown` on the trigger button opens the listbox and focuses the active option
- Visible `:focus` styles with `outline: 2px solid transparent` fallback for Forced Colors mode

## Notes on the VideoPlayer inert fix (#115)

Added a `useEffect` in `Dashboard.tsx` that toggles the `inert` attribute on `#main-content` and the page `<header>` while a video is open. This prevents screen reader virtual-cursor navigation past the focus trap. Cleanup function clears `inert` on unmount.