### PR TITLE
fix: preserve feed video duration on embeddability cache hits

### DIFF
--- a/server/src/services/youtube.service.test.ts
+++ b/server/src/services/youtube.service.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const mockPlaylistItemsList = vi.fn();
 const mockSearchList = vi.fn();
 const mockSubscriptionsList = vi.fn();
+const mockVideosList = vi.fn();
 
 vi.mock('googleapis', () => {
   class MockOAuth2 {
@@ -16,6 +17,7 @@ vi.mock('googleapis', () => {
         playlistItems: { list: mockPlaylistItemsList },
         search: { list: mockSearchList },
         subscriptions: { list: mockSubscriptionsList },
+        videos: { list: mockVideosList },
       })),
     },
   };
@@ -65,6 +67,7 @@ import {
   getChannelVideos,
   searchVideos,
   getUserSubscriptions,
+  filterEmbeddableVideos,
 } from './youtube.service';
 
 const mockedUserFindUnique = vi.mocked(prisma.user.findUnique);
@@ -336,5 +339,90 @@ describe('getUserSubscriptions', () => {
     mockedUserFindUnique.mockResolvedValue(null);
 
     await expect(getUserSubscriptions('nonexistent')).rejects.toThrow('User not found');
+  });
+});
+
+describe('filterEmbeddableVideos', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('attaches duration from videos.list response and caches embeddable metadata', async () => {
+    mockedCacheGet.mockResolvedValue(undefined);
+    mockedUserFindUnique.mockResolvedValue(mockUser as any);
+    mockVideosList.mockResolvedValue({
+      data: {
+        items: [
+          {
+            id: 'v1',
+            status: { embeddable: true },
+            contentDetails: { duration: 'PT4M13S' },
+          },
+        ],
+      },
+    });
+
+    const result = await filterEmbeddableVideos('user-1', [
+      {
+        videoId: 'v1',
+        title: 'Video 1',
+        description: 'desc',
+        channelId: 'ch1',
+        channelTitle: 'Channel 1',
+        thumbnailUrl: 'http://thumb.jpg',
+        publishedAt: '2024-01-01T00:00:00Z',
+        source: 'subscription',
+      },
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.duration).toBe('PT4M13S');
+    expect(mockedCacheSet).toHaveBeenCalledWith(
+      'embeddable:v1',
+      { embeddable: true, duration: 'PT4M13S' },
+      3600,
+    );
+  });
+
+  it('attaches duration from cached embeddability metadata on cache hit', async () => {
+    mockedCacheGet.mockResolvedValue({ embeddable: true, duration: 'PT1M05S' } as any);
+
+    const result = await filterEmbeddableVideos('user-1', [
+      {
+        videoId: 'v1',
+        title: 'Video 1',
+        description: 'desc',
+        channelId: 'ch1',
+        channelTitle: 'Channel 1',
+        thumbnailUrl: 'http://thumb.jpg',
+        publishedAt: '2024-01-01T00:00:00Z',
+        source: 'search',
+      },
+    ]);
+
+    expect(mockVideosList).not.toHaveBeenCalled();
+    expect(result).toHaveLength(1);
+    expect(result[0]?.duration).toBe('PT1M05S');
+  });
+
+  it('supports legacy boolean cache entries without duration', async () => {
+    mockedCacheGet.mockResolvedValue(true as any);
+
+    const result = await filterEmbeddableVideos('user-1', [
+      {
+        videoId: 'v1',
+        title: 'Video 1',
+        description: 'desc',
+        channelId: 'ch1',
+        channelTitle: 'Channel 1',
+        thumbnailUrl: 'http://thumb.jpg',
+        publishedAt: '2024-01-01T00:00:00Z',
+        source: 'search',
+      },
+    ]);
+
+    expect(mockVideosList).not.toHaveBeenCalled();
+    expect(result).toHaveLength(1);
+    expect(result[0]?.duration).toBeUndefined();
   });
 });

--- a/server/src/services/youtube.service.ts
+++ b/server/src/services/youtube.service.ts
@@ -370,10 +370,14 @@ async function executeSearch(
 }
 
 const EMBEDDABLE_CACHE_TTL_SECONDS = 3600; // 1 hour
+interface EmbeddableCacheEntry {
+  embeddable: boolean;
+  duration?: string;
+}
 
 /**
  * Filter a list of videos to only those that are embeddable.
- * Uses videos.list with part=status in batches of 50.
+ * Uses videos.list with part=status,contentDetails in batches of 50.
  * Caches results per video ID. Fails open on API errors.
  */
 export async function filterEmbeddableVideos(
@@ -389,9 +393,17 @@ export async function filterEmbeddableVideos(
   // Check cache for each video
   for (const video of videos) {
     const cacheKey = `embeddable:${video.videoId}`;
-    const cached = await cache.get<boolean>(cacheKey);
+    const cached = await cache.get<boolean | EmbeddableCacheEntry>(cacheKey);
     if (cached !== undefined) {
-      embeddableMap.set(video.videoId, cached);
+      if (typeof cached === 'boolean') {
+        // Backward compatibility with existing boolean-only cache entries.
+        embeddableMap.set(video.videoId, cached);
+      } else {
+        embeddableMap.set(video.videoId, cached.embeddable);
+        if (cached.duration) {
+          durationMap.set(video.videoId, cached.duration);
+        }
+      }
     } else {
       uncachedVideoIds.push(video.videoId);
     }
@@ -419,10 +431,13 @@ export async function filterEmbeddableVideos(
             const isEmbeddable = item.status?.embeddable === true;
             embeddableMap.set(item.id, isEmbeddable);
             returnedIds.add(item.id);
-            await cache.set(`embeddable:${item.id}`, isEmbeddable, EMBEDDABLE_CACHE_TTL_SECONDS);
-            if (item.contentDetails?.duration) {
-              durationMap.set(item.id, item.contentDetails.duration);
-            }
+            const duration = item.contentDetails?.duration ?? undefined;
+            if (duration) durationMap.set(item.id, duration);
+            await cache.set<EmbeddableCacheEntry>(
+              `embeddable:${item.id}`,
+              { embeddable: isEmbeddable, duration },
+              EMBEDDABLE_CACHE_TTL_SECONDS,
+            );
           }
         }
 
@@ -430,7 +445,11 @@ export async function filterEmbeddableVideos(
         for (const id of batch) {
           if (!returnedIds.has(id)) {
             embeddableMap.set(id, false);
-            await cache.set(`embeddable:${id}`, false, EMBEDDABLE_CACHE_TTL_SECONDS);
+            await cache.set<EmbeddableCacheEntry>(
+              `embeddable:${id}`,
+              { embeddable: false },
+              EMBEDDABLE_CACHE_TTL_SECONDS,
+            );
           }
         }
       }


### PR DESCRIPTION
Feed cards already render duration, but feed payloads were inconsistent because duration was only attached on fresh `videos.list` enrichment. On embeddability cache hits, cached values were boolean-only and duration was dropped.

This change updates the embeddability cache model to store `{ embeddable, duration? }` metadata and rehydrates duration from both cache-hit and fresh-fetch paths inside `filterEmbeddableVideos`. It also keeps backward compatibility with legacy boolean cache entries, so existing cache data does not break filtering behavior.

### Tests
- Added regression coverage in `youtube.service.test.ts` for:
  - fresh `videos.list` duration enrichment
  - cache-hit duration enrichment
  - legacy boolean cache entries without duration
- Ran `server` test suite (`npm test`)
- Ran targeted `client` feed tests (`VideoCard`, `VideoFeed`, `useFeed`)
- Ran builds for both workspaces (`npm run build`)

Fixes: #210